### PR TITLE
Fix error: https can not translate.

### DIFF
--- a/src/js/com.js
+++ b/src/js/com.js
@@ -455,7 +455,7 @@ $.extend( {
 
         // 下面一部分是查询的接口
         method : 'GET' ,
-        url : 'http://fanyi.youdao.com/openapi.do' ,
+        url : '//fanyi.youdao.com/openapi.do' ,
 
         // 有道的使用量较大，所以多使用几个API
         data : [
@@ -559,7 +559,7 @@ $.extend( {
 
         // 下面一部分是查询的接口
         method : 'POST' ,
-        url : 'http://openapi.baidu.com/public/2.0/bmt/translate' ,
+        url : '//openapi.baidu.com/public/2.0/bmt/translate' ,
         data : [
             {
 


### PR DESCRIPTION
修复 https 下无法翻译的问题，例如在 https://github.com/ 下，现只修改验证了有道和百度的划词翻译（两个都支持 https）。其他的（例如朗读），还没做验证。
