### PR TITLE
Fix popup translate error and hide the play when the protocol is https.

### DIFF
--- a/src/css/content.css
+++ b/src/css/content.css
@@ -13,6 +13,10 @@
     font-weight: normal;
 }
 
+#_container_ .__play__.none {
+    display: none;
+}
+
 #_container_ li {
     list-style-type: none;
 }

--- a/src/js/com.js
+++ b/src/js/com.js
@@ -377,7 +377,8 @@ $.extend( {
             }
 
             $.ajax( {
-                url : this.url ,
+                // https 下用 https，http 或者弹出框（chrome://）使用 http
+                url : (location.protocol === 'https:' ? 'https:' : 'http:') + this.url ,
                 method : this.method ,
                 data : data
             } , function ( r , e ) {

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -184,6 +184,11 @@
                         t = t.replace( '{{pronunciation}}' , obj.phonetic );
                     }
 
+                    //https下无法朗读，屏蔽掉
+                    if ( location.protocol === 'https:' ) {
+                        t = t.replace( '__play__', '__play__ none');
+                    }
+
                     //相关内容（templateObj.relatedWords），在标签页中不处理，以免结果框过长
                 }
 


### PR DESCRIPTION
修复两个问题：
- 弹出框无法翻译的 bug：https 下用 https，http 或者弹出框（chrome://）使用 http。
- 现在朗读使用的是 http://fanyi.baidu.com/langdetect 这个接口，测试过 https 下无法正确朗读（即使改为 https 也不行），应该隐藏掉。
